### PR TITLE
test(utils): Add tests for getHighlightedValue

### DIFF
--- a/src/lib/DocSearch.js
+++ b/src/lib/DocSearch.js
@@ -98,14 +98,14 @@ class DocSearch {
     // Translate hits into smaller objects to be send to the template
     return groupedHits.map((hit) => {
       let url = hit.anchor ? `${hit.url}#${hit.anchor}` : hit.url;
-      let category = this.getHighlightedValue(hit, 'lvl0');
-      let subcategory = this.getHighlightedValue(hit, 'lvl1') || category;
+      let category = utils.getHighlightedValue(hit, 'lvl0');
+      let subcategory = utils.getHighlightedValue(hit, 'lvl1') || category;
       let displayTitle = utils.compact([
-        this.getHighlightedValue(hit, 'lvl2') || subcategory,
-        this.getHighlightedValue(hit, 'lvl3'),
-        this.getHighlightedValue(hit, 'lvl4'),
-        this.getHighlightedValue(hit, 'lvl5'),
-        this.getHighlightedValue(hit, 'lvl6')
+        utils.getHighlightedValue(hit, 'lvl2') || subcategory,
+        utils.getHighlightedValue(hit, 'lvl3'),
+        utils.getHighlightedValue(hit, 'lvl4'),
+        utils.getHighlightedValue(hit, 'lvl5'),
+        utils.getHighlightedValue(hit, 'lvl6')
       ]).join(' › ');
       let text = this.getSnippettedValue(hit, 'content');
 
@@ -119,11 +119,6 @@ class DocSearch {
         url: url
       };
     });
-  }
-
-  getHighlightedValue(object, key) {
-    let highlight = object._highlightResult[key];
-    return highlight ? highlight.value : object[key];
   }
 
   getSnippettedValue(object, key) {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -169,6 +169,33 @@ let utils = {
     });
     return results;
   },
+  /*
+   * Returns the highlighted value of the specified key in the specified object.
+   * If no highlighted value is available, will return the key value directly
+   * eg.
+   * getHighlightedValue({
+   *    _highlightResult: {
+   *      text: {
+   *        value: '<mark>foo</mark>'
+   *      }
+   *    },
+   *    text: 'foo'
+   * }, 'foo');
+   * =>
+   * '<mark>foo</mark>'
+   * @param {object} object Hit object returned by the Algolia API
+   * @param {string} property Object key to look for
+   * @return {string}
+   **/
+  getHighlightedValue(object, property) {
+    if (!object._highlightResult
+        || !object._highlightResult[property]
+        || !object._highlightResult[property].value) {
+      return object[property];
+    }
+    return object._highlightResult[property].value;
+  }
+
 
 };
 

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -3,6 +3,11 @@
 import jsdom from 'mocha-jsdom';
 import expect from 'expect';
 
+let ddescribe = describe.only;
+let xdescribe = describe.skip;
+let iit = it.only;
+let xit = it.skip;
+
 describe('utils', () => {
   var utils;
   jsdom();
@@ -212,6 +217,53 @@ describe('utils', () => {
 
       // Then
       expect(actual).toEqual([42, [], 'foo']);
+    });
+  });
+
+  describe('getHighlightedValue', () => {
+    it('should return the highlighted version if exists', () => {
+      // Given
+      let input = {
+        _highlightResult: {
+          text: {
+            value: '<mark>foo</mark>'
+          }
+        },
+        text: 'foo'
+      };
+
+      // When
+      let actual = utils.getHighlightedValue(input, 'text');
+
+      // Then
+      expect(actual).toEqual('<mark>foo</mark>');
+    });
+    it('should return the default key if no highlighted value', () => {
+      // Given
+      let input = {
+        _highlightResult: {
+          text: { }
+        },
+        text: 'foo'
+      };
+
+      // When
+      let actual = utils.getHighlightedValue(input, 'text');
+
+      // Then
+      expect(actual).toEqual('foo');
+    });
+    it('should return the default key if no highlight results', () => {
+      // Given
+      let input = {
+        text: 'foo'
+      };
+
+      // When
+      let actual = utils.getHighlightedValue(input, 'text');
+
+      // Then
+      expect(actual).toEqual('foo');
     });
   });
 });


### PR DESCRIPTION
Given a hit returned by the API and a key, will return the highlighted value if one is present, or the default key otherwise. Added some tests to it, and moved it to utils.