### PR TITLE
test(utils): Add tests for getSnippettedValue

### DIFF
--- a/src/lib/DocSearch.js
+++ b/src/lib/DocSearch.js
@@ -107,7 +107,7 @@ class DocSearch {
         utils.getHighlightedValue(hit, 'lvl5'),
         utils.getHighlightedValue(hit, 'lvl6')
       ]).join(' › ');
-      let text = this.getSnippettedValue(hit, 'content');
+      let text = utils.getSnippettedValue(hit, 'content');
 
       return {
         isCategoryHeader: hit.isCategoryHeader,
@@ -119,20 +119,6 @@ class DocSearch {
         url: url
       };
     });
-  }
-
-  getSnippettedValue(object, key) {
-    if (!object._snippetResult || !object._snippetResult[key].value) {
-      return object[key];
-    }
-    let snippet = object._snippetResult[key].value;
-    if (snippet[0] !== snippet[0].toUpperCase()) {
-      snippet = `…${snippet}`;
-    }
-    if (['.', '!', '?'].indexOf(snippet[snippet.length - 1]) === -1) {
-      snippet = `${snippet}…`;
-    }
-    return snippet;
   }
 
   getSuggestionTemplate() {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -180,7 +180,7 @@ let utils = {
    *      }
    *    },
    *    text: 'foo'
-   * }, 'foo');
+   * }, 'text');
    * =>
    * '<mark>foo</mark>'
    * @param {object} object Hit object returned by the Algolia API
@@ -194,6 +194,42 @@ let utils = {
       return object[property];
     }
     return object._highlightResult[property].value;
+  },
+  /*
+   * Returns the snippeted value of the specified key in the specified object.
+   * If no highlighted value is available, will return the key value directly.
+   * Will add starting and ending ellipsis (…) if we detect that a sentence is
+   * incomplete
+   * eg.
+   * getSnippetedValue({
+   *    _snippetResult: {
+   *      text: {
+   *        value: '<mark>This is an unfinished sentence</mark>'
+   *      }
+   *    },
+   *    text: 'This is an unfinished sentence'
+   * }, 'text');
+   * =>
+   * '<mark>This is an unefinished sentenced</mark>…'
+   * @param {object} object Hit object returned by the Algolia API
+   * @param {string} property Object key to look for
+   * @return {string}
+   **/
+  getSnippetedValue(object, property) {
+    if (!object._snippetResult
+        || !object._snippetResult[property]
+        || !object._snippetResult[property].value) {
+      return object[property];
+    }
+    let snippet = object._snippetResult[property].value;
+
+    if (snippet[0] !== snippet[0].toUpperCase()) {
+      snippet = `…${snippet}`;
+    }
+    if (['.', '!', '?'].indexOf(snippet[snippet.length - 1]) === -1) {
+      snippet = `${snippet}…`;
+    }
+    return snippet;
   }
 
 

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -266,4 +266,71 @@ describe('utils', () => {
       expect(actual).toEqual('foo');
     });
   });
+
+  describe('getSnippetedValue', () => {
+    it('should return the key value if no snippet returned', () => {
+      // Given
+      let input = {
+        text: 'Foo'
+      };
+
+      // When
+      let actual = utils.getSnippetedValue(input, 'text');
+
+      // Then
+      expect(actual).toEqual('Foo');
+    });
+    it('should return the key value if no snippet for this key', () => {
+      // Given
+      let input = {
+        _snippetResult: {
+          content: {
+            value: '<mark>Bar</mark>'
+          }
+        },
+        text: 'Foo',
+        content: 'Bar'
+      };
+
+      // When
+      let actual = utils.getSnippetedValue(input, 'text');
+
+      // Then
+      expect(actual).toEqual('Foo');
+    });
+    it('should add ellipsis at the start if snippet does not start with a capital letter', () => {
+      // Given
+      let input = {
+        _snippetResult: {
+          text: {
+            value: 'this is the <mark>end</mark> of a sentence.'
+          }
+        },
+        text: 'this is the end of a sentence.'
+      };
+
+      // When
+      let actual = utils.getSnippetedValue(input, 'text');
+
+      // Then
+      expect(actual).toEqual('…this is the <mark>end</mark> of a sentence.');
+    });
+    it('should add ellipsis at the end if snippet does not end with a terminal point', () => {
+      // Given
+      let input = {
+        _snippetResult: {
+          text: {
+            value: 'This is an <mark>finished</mark> sentence'
+          }
+        },
+        text: 'This is an <mark>finished</mark> sentence'
+      };
+
+      // When
+      let actual = utils.getSnippetedValue(input, 'text');
+
+      // Then
+      expect(actual).toEqual('This is an <mark>finished</mark> sentence…');
+    });
+  });
 });


### PR DESCRIPTION
Same underlying logic than getHighlightedValue, but also add prefix
and suffix ellipsis (…) when we detect that a snippet is truncating
a sentence.